### PR TITLE
Update tensorflow

### DIFF
--- a/tf2rust/requirements.txt
+++ b/tf2rust/requirements.txt
@@ -3,4 +3,4 @@ nose==1.3.7
 numpy==1.23.4
 pydot==1.4.2
 scikit-learn==1.1.3
-tensorflow==2.8.3
+tensorflow==2.8.4


### PR DESCRIPTION
Update tensorflow to 2.8.4 to prevent [CVE-2022-41894](https://github.com/advisories/GHSA-h6q3-vv32-2cq5)